### PR TITLE
fix: Correctly destroy self bubble cooldown text in hideSelfBubbleCD …

### DIFF
--- a/src/heroes/zarya/self_bubble.opy
+++ b/src/heroes/zarya/self_bubble.opy
@@ -11,7 +11,7 @@ def showSelfBubbleCD():
 def hideSelfBubbleCD():
     @Name "[zarya/self_bubble.opy]: hideSelfBubbleCD()"
     
-    destroyInWorldText(eventPlayer._zarya_ally_bubble_cd)
+    destroyInWorldText(eventPlayer._zarya_self_bubble_cd)
     eventPlayer._zarya_ally_bubble_cd = null
     destroyInWorldText(eventPlayer._zarya_self_bubble_icon)
     eventPlayer._zarya_self_bubble_icon = null


### PR DESCRIPTION
Fix for the ally bubble text being destroyed instead of self bubble.