### PR TITLE
Movespeed changes, timers math.infinity

### DIFF
--- a/src/heroes/ana/sleep.opy
+++ b/src/heroes/ana/sleep.opy
@@ -4,7 +4,7 @@ rule "[ana/sleep.opy]: Sleep tanks as long as other heroes":
     @Condition eventAbility == Button.ABILITY_1
     @Condition victim.getHero() in getTankHeroes() == true
     
-    waitUntil(victim.hasStatus(Status.ASLEEP), 999999986991104)
+    waitUntil(victim.hasStatus(Status.ASLEEP), Math.INFINITY)
     wait(0.2)
     victim.setStatusEffect(attacker, Status.KNOCKED_DOWN, 4.8)
     victim.Ana_Sleepdart_Target = true

--- a/src/heroes/baptiste/regen_burst.opy
+++ b/src/heroes/baptiste/regen_burst.opy
@@ -15,5 +15,5 @@ rule "[baptiste/regen_burst.opy]: Remove initial burst healing from Regenerative
     @Condition eventPlayer.isUsingAbility1() == true
     
     eventPlayer.setHealingDealt(0)
-    waitUntil(not eventPlayer.isUsingAbility1(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility1(), Math.INFINITY)
     eventPlayer.setHealingDealt(100 * eventPlayer._base_healing_scalar)

--- a/src/heroes/bastion/reconfigure.opy
+++ b/src/heroes/bastion/reconfigure.opy
@@ -9,7 +9,7 @@ rule "[bastion/reconfigure.opy]: Reduce assault form damage and movement speed":
     wait(0.95)
     eventPlayer.startHealingOverTime(eventPlayer, 8, 15)
     eventPlayer.sentry_healing_id = getLastHealingOverTimeId()
-    waitUntil(not eventPlayer.isUsingAbility1(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility1(), Math.INFINITY)
     eventPlayer.setDamageReceived(100)
     eventPlayer._current_move_speed = eventPlayer._current_move_speed + 15
     eventPlayer.setMoveSpeed(eventPlayer._current_move_speed)

--- a/src/heroes/cassidy/deadeye.opy
+++ b/src/heroes/cassidy/deadeye.opy
@@ -4,5 +4,5 @@ rule "[cassidy/deadeye.opy]: Set damage during deadeye":
     @Condition eventPlayer.isUsingUltimate() == true
     
     eventPlayer.setDamageDealt(100)
-    waitUntil(not eventPlayer.isUsingUltimate(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingUltimate(), Math.INFINITY)
     eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)

--- a/src/heroes/dva/defense_matrix.opy
+++ b/src/heroes/dva/defense_matrix.opy
@@ -3,7 +3,7 @@ rule "[dva/defense_matrix.opy]: Increase Defense Matrix cooldown":
     @Hero dva
     @Condition eventPlayer.isFiringSecondaryFire() == true
     
-    waitUntil(not eventPlayer.isFiringSecondaryFire(), 999999986991104)
+    waitUntil(not eventPlayer.isFiringSecondaryFire(), Math.INFINITY)
     eventPlayer.setSecondaryFireEnabled(false)
     wait(1.5)
     eventPlayer.setSecondaryFireEnabled(true)

--- a/src/heroes/dva/init.opy
+++ b/src/heroes/dva/init.opy
@@ -15,7 +15,7 @@ def initDva():
     eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)
     eventPlayer.self_destruct_charge = 0
     eventPlayer.max_health_scaler = 0.857
-    waitUntil(not eventPlayer.isInAlternateForm(), 999999986991104)
+    waitUntil(not eventPlayer.isInAlternateForm(), Math.INFINITY)
     eventPlayer.custom_hp_pvar[0] = 169
     eventPlayer.custom_hp_pvar[1] = 0
     eventPlayer.custom_hp_pvar[2] = 0

--- a/src/heroes/illari/solar_rifle.opy
+++ b/src/heroes/illari/solar_rifle.opy
@@ -15,5 +15,5 @@ rule "[illari/solar_rifle.opy]: Correct Solar Rifle healing":
     @Condition eventPlayer.isHoldingButton(Button.SECONDARY_FIRE) == true
     
     eventPlayer.setHealingDealt(100)
-    waitUntil(not eventPlayer.isHoldingButton(Button.SECONDARY_FIRE), 999999986991104)
+    waitUntil(not eventPlayer.isHoldingButton(Button.SECONDARY_FIRE), Math.INFINITY)
     eventPlayer.setHealingDealt(75)

--- a/src/heroes/junkerqueen/carnage.opy
+++ b/src/heroes/junkerqueen/carnage.opy
@@ -4,5 +4,5 @@ rule "[junkerqueen/carnage.opy]: Reduce Carnage damage":
     @Condition eventPlayer.isUsingAbility2() == true
     
     eventPlayer.setDamageDealt(85.714)
-    waitUntil(not eventPlayer.isUsingAbility2(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility2(), Math.INFINITY)
     eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)

--- a/src/heroes/junkerqueen/rampage.opy
+++ b/src/heroes/junkerqueen/rampage.opy
@@ -4,6 +4,6 @@ rule "[junkerqueen/rampage.opy]: Reduce Rampage damage":
     @Condition eventPlayer.isUsingUltimate() == true
     
     eventPlayer.setDamageDealt(83.333)
-    waitUntil(not eventPlayer.isUsingUltimate(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingUltimate(), Math.INFINITY)
     eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)
 

--- a/src/heroes/kiriko/swift_step.opy
+++ b/src/heroes/kiriko/swift_step.opy
@@ -2,7 +2,7 @@ rule "[kiriko/swift_step.opy]: Force swift step cooldown after spawning":
     @Event playerDied
     @Hero kiriko
     
-    waitUntil(eventPlayer.isAlive() and eventPlayer.isInSpawnRoom(), 999999986991104)
+    waitUntil(eventPlayer.isAlive() and eventPlayer.isInSpawnRoom(), Math.INFINITY)
     eventPlayer.setAbilityCooldown(Button.ABILITY_1, 5)
 
 

--- a/src/heroes/mei/cryo_freeze.opy
+++ b/src/heroes/mei/cryo_freeze.opy
@@ -4,5 +4,5 @@ rule "[mei/cryo_freeze.opy]: OW1 Cryo-Freeze healing set to 80 otherwise for tan
     @Condition eventPlayer.isUsingAbility1() == true
     
     eventPlayer.setHealingReceived(80)
-    waitUntil(not eventPlayer.isUsingAbility1(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility1(), Math.INFINITY)
     eventPlayer.setHealingReceived(100)

--- a/src/heroes/mercy/init.opy
+++ b/src/heroes/mercy/init.opy
@@ -41,7 +41,7 @@ rule "[mercy/init.opy]: Reduce Valkyrie healing and force self-healing":
     eventPlayer.setHealingDealt(138.462)
     wait(2)
     eventPlayer.setHealingDealt(92.308)
-    waitUntil(not eventPlayer.isUsingUltimate(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingUltimate(), Math.INFINITY)
     eventPlayer.setHealingDealt(100 * eventPlayer._base_healing_scalar)
 
 

--- a/src/heroes/moira/coalescence.opy
+++ b/src/heroes/moira/coalescence.opy
@@ -4,5 +4,5 @@ rule "[moira/coalescence.opy]: Prevent fading during Coalescence":
     @Condition eventPlayer.isUsingUltimate() == true
     
     eventPlayer.setDamageDealt(82.353)
-    waitUntil(not eventPlayer.isUsingUltimate(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingUltimate(), Math.INFINITY)
     eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)

--- a/src/heroes/orisa/terra_surge.opy
+++ b/src/heroes/orisa/terra_surge.opy
@@ -6,7 +6,7 @@ rule "[orisa/terra_surge.opy]: Reduce Terra Surge base damage and add bonus over
     eventPlayer.addHealthPool(Health.NORMAL, 181, false)
     eventPlayer.terra_overhealth_id = getLastCreatedHealthPool()
     eventPlayer.setDamageDealt(80)
-    waitUntil(not eventPlayer.isUsingUltimate(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingUltimate(), Math.INFINITY)
     eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)
     removeHealthPool(eventPlayer.terra_overhealth_id)
 

--- a/src/heroes/ramattra/nemesis_form.opy
+++ b/src/heroes/ramattra/nemesis_form.opy
@@ -10,7 +10,7 @@ rule "[ramattra/nemesis_form.opy]: Correct Nemesis Form armor and movement speed
     #for some reason the addHealthPool function doesn't read constants as usable numbers
     eventPlayer.addHealthPool(Health.ARMOR, 11, true, false)
     eventPlayer.Nemesis_armor = getLastCreatedHealthPool()
-    waitUntil(not eventPlayer.isUsingAbility1(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility1(), Math.INFINITY)
     eventPlayer._current_move_speed += 16.6
     eventPlayer.setMoveSpeed(eventPlayer._current_move_speed)
     eventPlayer.stopScalingSize()

--- a/src/heroes/reaper/init.opy
+++ b/src/heroes/reaper/init.opy
@@ -29,5 +29,5 @@ rule "[reaper/init.opy]: Reduce Death Blossom damage":
     @Condition eventPlayer.isUsingUltimate() == true
     
     eventPlayer.setDamageDealt(91.892)
-    waitUntil(not eventPlayer.isUsingUltimate(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingUltimate(), Math.INFINITY)
     eventPlayer.setDamageDealt(98.148)

--- a/src/heroes/roadhog/breather.opy
+++ b/src/heroes/roadhog/breather.opy
@@ -6,5 +6,5 @@ rule "[roadhog/breather.opy]: Adjust Breather efficacy":
     eventPlayer.setHealingDealt(222.222)
     wait(0.8)
     eventPlayer.setHealingDealt(48.387)
-    waitUntil(not eventPlayer.isFiringSecondaryFire(), 999999986991104)
+    waitUntil(not eventPlayer.isFiringSecondaryFire(), Math.INFINITY)
     eventPlayer.setHealingDealt(100)

--- a/src/heroes/sigma/kinetic_grasp.opy
+++ b/src/heroes/sigma/kinetic_grasp.opy
@@ -5,5 +5,5 @@ rule "[sigma/kinetic_grasp.opy]: Reduce Kinetic Grasp overhealth":
     
     wait(1.2, Wait.ABORT_WHEN_FALSE)
     eventPlayer.hp_exiting_grasp = eventPlayer.getHealth()
-    waitUntil(not eventPlayer.isUsingAbility1(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility1(), Math.INFINITY)
     damage(eventPlayer, null, 0.3 * (eventPlayer.getHealth() - eventPlayer.hp_exiting_grasp))

--- a/src/heroes/sombra/translocator.opy
+++ b/src/heroes/sombra/translocator.opy
@@ -37,7 +37,7 @@ rule "[sombra/translocator.opy]: When Translocator is used, begin tracking how l
     
     #eventPlayer.Sombra_invis_damage = 0
     eventPlayer.stealth_timer = 5.5
-    waitUntil(not eventPlayer.isUsingAbility2(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility2(), Math.INFINITY)
     eventPlayer.Sombra_invisible = true
     chaseAtRate(eventPlayer.stealth_timer, 0, 1, ChaseRateReeval.NONE)
     #Sombra can't break stealth during the cast time of stealth
@@ -69,7 +69,7 @@ rule "[sombra/translocator.opy]: When Translocator is used, begin tracking how l
     
     #eventPlayer.Sombra_invis_damage = 0
     eventPlayer.stealth_timer = 4.82
-    waitUntil(not eventPlayer.isUsingAbility2(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility2(), Math.INFINITY)
     eventPlayer.Sombra_invisible = true
     chaseAtRate(eventPlayer.stealth_timer, 0, 1, ChaseRateReeval.NONE)
     #Sombra can't break stealth during the cast time of stealth

--- a/src/heroes/torbjorn/init.opy
+++ b/src/heroes/torbjorn/init.opy
@@ -33,6 +33,6 @@ rule "[torbjorn/init.opy]: Increase Overload overhealth":
     
     eventPlayer.addHealthPool(Health.NORMAL, 22.3, false)
     eventPlayer.overload_overhealth = getLastCreatedHealthPool()
-    waitUntil(not eventPlayer.isUsingAbility2(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility2(), Math.INFINITY)
     removeHealthPool(eventPlayer.overload_overhealth)
 

--- a/src/heroes/widowmaker/init.opy
+++ b/src/heroes/widowmaker/init.opy
@@ -21,5 +21,5 @@ rule "[widowmaker/init.opy]: Reduce Scoped Shot damage":
     @Disabled
     
     eventPlayer.setDamageDealt(87.5)
-    waitUntil(not eventPlayer.isFiringSecondaryFire(), 999999986991104)
+    waitUntil(not eventPlayer.isFiringSecondaryFire(), Math.INFINITY)
     eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)

--- a/src/heroes/winston/primal.opy
+++ b/src/heroes/winston/primal.opy
@@ -5,7 +5,7 @@ rule "[winston/primal.opy]: Remove bonus Primal Rage health":
     
     clearCustomHp()
     eventPlayer.addHealthPool(Health.ARMOR, 15, true, false)
-    waitUntil(not eventPlayer.isUsingUltimate(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingUltimate(), Math.INFINITY)
     clearCustomHp()
     applyCustomHp()
 
@@ -16,7 +16,7 @@ rule "[winston/primal.opy]: Reduce Primal Rage damage":
     @Condition eventPlayer.isUsingUltimate() == true
     
     eventPlayer.setDamageDealt(80)
-    waitUntil(not eventPlayer.isUsingUltimate(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingUltimate(), Math.INFINITY)
     #revert damage back after Primal Rage concludes
     eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)
 

--- a/src/heroes/wreckingball/grapple.opy
+++ b/src/heroes/wreckingball/grapple.opy
@@ -3,7 +3,7 @@ rule "[wreckingball/grapple.opy]: Force Grappling Hook cooldown":
     @Hero wreckingBall
     @Condition eventPlayer.isFiringSecondaryFire() == true
     
-    waitUntil(eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE) > 0, 999999986991104)
+    waitUntil(eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE) > 0, Math.INFINITY)
     if eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE) <= 1:
         eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, 1.92)
 

--- a/src/heroes/wreckingball/shields.opy
+++ b/src/heroes/wreckingball/shields.opy
@@ -5,7 +5,7 @@ rule "[wreckingball/shields.opy]: Remove Adaptive Shields overhealth transfer":
     
     eventPlayer.disallowButton(Button.ABILITY_2)
     eventPlayer.setAbility2Enabled(false)
-    waitUntil(not eventPlayer.isUsingAbility2(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility2(), Math.INFINITY)
     enableAllAbilities()
     eventPlayer.allowButton(Button.ABILITY_2)
 
@@ -17,6 +17,6 @@ rule "[wreckingball/shields.opy]: Increase Adaptive Shield base overhealth gain"
     
     eventPlayer.addHealthPool(Health.NORMAL, 100, false)
     eventPlayer.adaptive_overhealth_id = getLastCreatedHealthPool()
-    waitUntil(not eventPlayer.isUsingAbility2(), 999999986991104)
+    waitUntil(not eventPlayer.isUsingAbility2(), Math.INFINITY)
     removeHealthPool(eventPlayer.adaptive_overhealth_id)
     eventPlayer.adaptive_overhealth_id = null

--- a/src/utilities/anti_crash.opy
+++ b/src/utilities/anti_crash.opy
@@ -4,5 +4,5 @@ rule "[utilities/anti_crash.opy]: Activate anti crash":
     wait(ANTI_CRASH_HOLD_TIME, Wait.ABORT_WHEN_FALSE)
     smallMessage(getAllPlayers(), "Crash protection in progress...")
     setSlowMotion(1)
-    waitUntil(getServerLoad() < ANTI_CRASH_DEACTIVATE_PERCENT, 999999986991104)
+    waitUntil(getServerLoad() < ANTI_CRASH_DEACTIVATE_PERCENT, Math.INFINITY)
     setSlowMotion(100)

--- a/src/utilities/custom_hp.opy
+++ b/src/utilities/custom_hp.opy
@@ -13,7 +13,7 @@ def applyCustomHp():
     #eventPlayer.addHealthPool(Health.NORMAL, 1, true)
     #eventPlayer.addHealthPool(Health.ARMOR, 1, true)
     #eventPlayer.addHealthPool(Health.SHIELDS, 1, true)
-    eventPlayer.setStatusEffect(null, Status.INVINCIBLE, 999999986991104)
+    eventPlayer.setStatusEffect(null, Status.INVINCIBLE, Math.INFINITY)
     #eventPlayer.removeAllHealthPools()
     #wait(0.064)
     wait()
@@ -26,5 +26,5 @@ def applyCustomHp():
     if eventPlayer.custom_hp_pvar[2] > 0:
         eventPlayer.addHealthPool(Health.SHIELDS, max(1, eventPlayer.custom_hp_pvar[2]), true)
     #eventPlayer.setHealingReceived(100)
-    heal(eventPlayer, null, 999999986991104)
+    heal(eventPlayer, null, Math.INFINITY)
     eventPlayer.clearStatusEffect(Status.INVINCIBLE)

--- a/src/utilities/hero_switch.opy
+++ b/src/utilities/hero_switch.opy
@@ -8,13 +8,12 @@ rule "[utilities/hero_switch.opy]: detect hero switch":
     #eventPlayer._hero_id = heroID(eventPlayer._last_hero_played)
     eventPlayer.hero_switch_pvar[1] = false
 
-
 rule "[utilities/hero_switch.opy]: Initialize hero on hero switch":
     @Event eachPlayer
     @Condition eventPlayer.hero_switch_pvar[1] != false
     
-    waitUntil(eventPlayer.hasSpawned(), 999999986991104)
-    waitUntil(not eventPlayer.hero_switch_pvar[1], 999999986991104)
+    waitUntil(eventPlayer.hasSpawned(), Math.INFINITY)
+    waitUntil(not eventPlayer.hero_switch_pvar[1], Math.INFINITY)
     eventPlayer.hero_setup = eventPlayer.getHero()
     resetHero()
     initHero()
@@ -24,6 +23,6 @@ rule "[utilities/hero_switch.opy]: Reinitialize hero on new round":
     @Event eachPlayer
     @Condition isMatchBetweenRounds() == true
     
-    waitUntil(not isMatchBetweenRounds(), 999999986991104)
+    waitUntil(not isMatchBetweenRounds(), Math.INFINITY)
     resetHero()
     initHero()

--- a/src/utilities/reset.opy
+++ b/src/utilities/reset.opy
@@ -61,28 +61,28 @@ def resetStats():
     @Name "[utilities/reset.opy]: resetStats()"
     
     eventPlayer._base_damage_scalar = 1
-    eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)
-    eventPlayer.setDamageReceived(100)
-    eventPlayer.setProjectileSpeed(100)
-    eventPlayer.setProjectileGravity(100)
+    eventPlayer.max_health_scaler = 1
+    eventPlayer._current_damage_received = 100
     eventPlayer._base_healing_scalar = 1
-    eventPlayer.setHealingDealt(100 * eventPlayer._base_healing_scalar)
-    eventPlayer.setHealingReceived(100)
+    eventPlayer._current_move_speed = 100
+    eventPlayer.stopForcingButton(Button.PRIMARY_FIRE)
+    eventPlayer.stopAllDamageOverTime()
+    eventPlayer.stopAllHealingOverTime()
+    eventPlayer.setMoveSpeed(eventPlayer._current_move_speed)
+    eventPlayer.setDamageDealt(100 * eventPlayer._base_damage_scalar)
+    eventPlayer.setDamageReceived(eventPlayer._current_damage_received)
     eventPlayer.setKnockbackReceived(100)
     eventPlayer.setKnockbackDealt(100)
+    eventPlayer.setHealingDealt(100 * eventPlayer._base_healing_scalar)
+    eventPlayer.setHealingReceived(100)
+    eventPlayer.setProjectileSpeed(100)
+    eventPlayer.setProjectileGravity(100)
     #eventPlayer.setGravity(100)
     #eventPlayer.setJumpVerticalSpeed(100) # might be responsible for jump bug
-    eventPlayer._current_move_speed = 1
-    eventPlayer.setMoveSpeed(100 * eventPlayer._current_move_speed)
     eventPlayer.stopScalingSize()
     eventPlayer.stopScalingBarriers()
     #prevent wholehog from keeping primary fire held
-    eventPlayer.stopForcingButton(Button.PRIMARY_FIRE)
-    eventPlayer.max_health_scaler = 1
-    eventPlayer.stopAllDamageOverTime()
-    eventPlayer.stopAllHealingOverTime()
-    eventPlayer._current_damage_received = 100
-    eventPlayer._current_move_speed = 100
+
 
 
 def resetStatuses():


### PR DESCRIPTION
Use Math.INFINITY for all timers instead of a value that might not persist for the total length of a custom game.

Updated the resetStats the call to setMoveSpeed and simplify assignment of current movespeed to 100.